### PR TITLE
minor typo

### DIFF
--- a/manuscript/markdown/1.choice.md
+++ b/manuscript/markdown/1.choice.md
@@ -75,7 +75,7 @@ Our logical operators `!`, `&&`, and `||` are a little more subtle than our exam
     !undefined
       //=> true
 
-Programmers often take advantage of this behaviour to observe that `!!(someExpression)` will always evaluate to `true` is `someExpression` is truthy, and to `false` if it is not. So in JavaScript (and other languages with similar semantics), when you see something like `!!currentUser()`, this is an idiom that means "true if currentUser is truthy." Thus, a function like `currentUser()` is free to return `null`, or `undefined`, or `false` if there is no current user.
+Programmers often take advantage of this behaviour to observe that `!!(someExpression)` will always evaluate to `true` if `someExpression` is truthy, and to `false` if it is not. So in JavaScript (and other languages with similar semantics), when you see something like `!!currentUser()`, this is an idiom that means "true if currentUser is truthy." Thus, a function like `currentUser()` is free to return `null`, or `undefined`, or `false` if there is no current user.
 
 Thus, `!!` is the way we write "is truthy" in JavaScript. How about `&&` and `||`? What haven't we discussed?
 


### PR DESCRIPTION
 "will always evaluate to `true` IS `someExpression` is truthy,"
->
 "will always evaluate to `true` IF `someExpression` is truthy,"
