### PR TITLE
Small Markdown Fix - Correctly formatting comment

### DIFF
--- a/manuscript/markdown/1.ComposingData/mutation.md
+++ b/manuscript/markdown/1.ComposingData/mutation.md
@@ -22,8 +22,8 @@ You can do the same thing with both syntaxes for accessing objects:
     name.middleName = 'Austin'
     name
       //=> { firstName: 'Leonard',
-      #     lastName: 'Braithwaite',
-      #     middleName: 'Austin' }
+      //    lastName: 'Braithwaite',
+      //    middleName: 'Austin' }
 
 We have established that JavaScript's semantics allow for two different bindings to refer to the same value. For example:
 


### PR DESCRIPTION
The two lines edited were incorrectly displayed as code and not as part of a comment (output)