### PR TITLE
const: Use === for comparison

### DIFF
--- a/manuscript/markdown/0.Functions/const.md
+++ b/manuscript/markdown/0.Functions/const.md
@@ -421,7 +421,7 @@ By default, JavaScript permits us to *rebind* new values to names bound with a p
       if (n === 0) {
         return true;
       }
-      else if (n == 1) {
+      else if (n === 1) {
         return false;
       }
       else {
@@ -439,7 +439,7 @@ The line `n = n - 2;` *rebinds* a new value to the name `n`. We will discuss thi
       if (n === 0) {
         return true;
       }
-      else if (n == 1) {
+      else if (n === 1) {
         return false;
       }
       else {


### PR DESCRIPTION
In "values and identity" paragraph, the operator for comparison is `===`. `==` was not introduced yet.