### PR TITLE
Update 1.iterables.md

### DIFF
--- a/manuscript/markdown/3.Collections/1.iterables.md
+++ b/manuscript/markdown/3.Collections/1.iterables.md
@@ -159,7 +159,7 @@ const Stack2 = () =>
       let iterationIndex = this.index;
 
       return {
-        next () {
+        next: () => {
           if (iterationIndex > this.index) {
             iterationIndex = this.index;
           }

--- a/manuscript/markdown/3.Collections/1.iterables.md
+++ b/manuscript/markdown/3.Collections/1.iterables.md
@@ -237,7 +237,7 @@ const Stack3 = () =>
       let iterationIndex = this.index;
 
       return {
-        next () {
+        next: () => {
           if (iterationIndex > this.index) {
             iterationIndex = this.index;
           }


### PR DESCRIPTION
when next() being called, it needs to understand it's enclosing environment, which share the same `this` of `this.index`.

Otherwise `this.array` is `undefined` and this is {next()(...)}.
![image](https://user-images.githubusercontent.com/4665929/59648610-ff096700-91c2-11e9-9e4a-1efc4f936233.png)
